### PR TITLE
Fix unwanted echo in sprintf function

### DIFF
--- a/includes/class-post-type-admin.php
+++ b/includes/class-post-type-admin.php
@@ -143,7 +143,7 @@ class Team_Post_Type_Admin {
 			$options .= sprintf(
 				'<option value="%s"%s />%s</option>',
 				esc_attr( $term->slug ),
-				selected( $current_tax_slug, $term->slug ),
+				selected( $current_tax_slug, $term->slug, false ),
 				esc_html( $term->name . '(' . $term->count . ')' )
 			);
 		}


### PR DESCRIPTION
Fixes a unwanted echo in the select option of the taxonomy admin filter